### PR TITLE
Feat/local images

### DIFF
--- a/src/backend/deployment.rs
+++ b/src/backend/deployment.rs
@@ -1060,6 +1060,7 @@ impl IoTDeployer {
         architecture: Option<String>,
         minimal: bool,
         skip_custom: bool,
+        image_filter: Option<Vec<String>>,
     ) -> Result<(), TelegrafError> {
         self.progress("🐳 Pushing Docker images to device...");
 
@@ -1080,17 +1081,64 @@ impl IoTDeployer {
         self.progress(&format!("   Target platform: {}", platform));
         self.progress(&format!("   Docker context: {}", docker_context.display()));
 
-        let mut images_to_pull = vec![
-            "influxdb:2",
-            "telegraf:1.30",
-            "chronograf:1.10",
-            "nginx:alpine",
-            "alpine:3.19",
+        let all_images: Vec<(&str, &str)> = vec![
+            ("influxdb", "influxdb:2"),
+            ("telegraf", "telegraf:1.30"),
+            ("chronograf", "chronograf:1.10"),
+            ("nginx", "nginx:alpine"),
+            ("alpine", "alpine:3.19"),
+            ("grafana", "grafana/grafana:latest"),
+            ("prometheus", "prom/prometheus:latest"),
         ];
 
-        if !minimal {
-            images_to_pull.push("grafana/grafana:latest");
-            images_to_pull.push("prom/prometheus:latest");
+        let minimal_names: &[&str] = &["influxdb", "telegraf", "chronograf", "nginx", "alpine"];
+
+        let images_to_pull: Vec<&str> = match &image_filter {
+            Some(filter) => {
+                let filter_lower: Vec<String> = filter.iter().map(|s| s.to_lowercase()).collect();
+                all_images.iter()
+                    .filter(|(name, _)| filter_lower.iter().any(|f| f == &name.to_lowercase()))
+                    .map(|(_, tag)| *tag)
+                    .collect()
+            }
+            None => {
+                if minimal {
+                    all_images.iter()
+                        .filter(|(name, _)| minimal_names.contains(name))
+                        .map(|(_, tag)| *tag)
+                        .collect()
+                } else {
+                    all_images.iter().map(|(_, tag)| *tag).collect()
+                }
+            }
+        };
+
+        let custom_services: Vec<(&str, &str)> = vec![
+            ("api-service", "api-service/Dockerfile.prebuilt"),
+            ("control-service", "control-service/Dockerfile.prebuilt"),
+        ];
+
+        let services_to_build: Vec<(&str, &str)> = if skip_custom {
+            vec![]
+        } else if let Some(filter) = &image_filter {
+            let filter_lower: Vec<String> = filter.iter().map(|s| s.to_lowercase()).collect();
+            custom_services.iter()
+                .filter(|(name, _)| filter_lower.iter().any(|f| f == &name.to_lowercase()))
+                .cloned()
+                .collect()
+        } else {
+            custom_services.clone()
+        };
+
+        if images_to_pull.is_empty() && services_to_build.is_empty() {
+            self.progress("ℹ️  No images selected. Use --images to specify which images to push, or omit it to push all.");
+            return Ok(());
+        }
+
+        self.progress(&format!("   Images to pull: {}", images_to_pull.join(", ")));
+        if !services_to_build.is_empty() {
+            let build_names: Vec<&str> = services_to_build.iter().map(|(n, _)| *n).collect();
+            self.progress(&format!("   Services to build: {}", build_names.join(", ")));
         }
 
         // Phase 1: Pull and save images locally
@@ -1145,13 +1193,8 @@ impl IoTDeployer {
         }
 
         // Build custom images (api-service and control-service)
-        if !skip_custom {
-            let custom_services = [
-                ("api-service", "api-service/Dockerfile.prebuilt"),
-                ("control-service", "control-service/Dockerfile.prebuilt"),
-            ];
-
-            for (service_name, dockerfile) in &custom_services {
+        if !services_to_build.is_empty() {
+            for (service_name, dockerfile) in &services_to_build {
                 let image_tag = format!("{}:local", service_name);
 
                 self.progress(&format!("🔨 Building custom image {}...", image_tag));
@@ -1202,7 +1245,7 @@ impl IoTDeployer {
 
                 tar_files.push((image_tag, tar_path));
             }
-        } else {
+        } else if skip_custom {
             self.progress("⏭️  Skipping custom service images (--skip-custom)");
         }
 

--- a/src/backend/deployment.rs
+++ b/src/backend/deployment.rs
@@ -1061,24 +1061,47 @@ impl IoTDeployer {
         minimal: bool,
         skip_custom: bool,
         image_filter: Option<Vec<String>>,
+        save_dir: Option<std::path::PathBuf>,
+        load_dir: Option<std::path::PathBuf>,
     ) -> Result<(), TelegrafError> {
-        self.progress("🐳 Pushing Docker images to device...");
+        if save_dir.is_some() && load_dir.is_some() {
+            return Err(TelegrafError::ConfigError(
+                "Cannot use --save-dir and --load-dir together.".to_string(),
+            ));
+        }
 
-        let arch = match architecture {
-            Some(a) => {
-                self.progress(&format!("   Using specified architecture: {}", a));
-                a
+        let (arch, needs_device) = if load_dir.is_some() {
+            (architecture.unwrap_or_else(|| "arm64".to_string()), true)
+        } else if save_dir.is_some() {
+            match architecture {
+                Some(a) => (a, false),
+                None => return Err(TelegrafError::ConfigError(
+                    "--architecture is required when using --save-dir (no device to auto-detect from).".to_string(),
+                )),
             }
-            None => {
-                self.progress("   Detecting device architecture...");
-                self.detect_architecture()?
-            }
+        } else {
+            let a = match architecture {
+                Some(a) => {
+                    self.progress(&format!("   Using specified architecture: {}", a));
+                    a
+                }
+                None => {
+                    self.progress("   Detecting device architecture...");
+                    self.detect_architecture()?
+                }
+            };
+            (a, true)
         };
 
         let platform = format!("linux/{}", arch);
         let docker_context = self.find_docker_context()?;
 
         self.progress(&format!("   Target platform: {}", platform));
+        if !needs_device {
+            self.progress("   Save-only mode: images will be saved locally (no device connection needed)");
+        } else if load_dir.is_some() {
+            self.progress("   Load-only mode: using pre-saved image tars (no Docker needed on host)");
+        }
         self.progress(&format!("   Docker context: {}", docker_context.display()));
 
         let all_images: Vec<(&str, &str)> = vec![
@@ -1118,7 +1141,7 @@ impl IoTDeployer {
             ("control-service", "control-service/Dockerfile.prebuilt"),
         ];
 
-        let services_to_build: Vec<(&str, &str)> = if skip_custom {
+        let services_to_build: Vec<(&str, &str)> = if skip_custom || load_dir.is_some() {
             vec![]
         } else if let Some(filter) = &image_filter {
             let filter_lower: Vec<String> = filter.iter().map(|s| s.to_lowercase()).collect();
@@ -1135,103 +1158,45 @@ impl IoTDeployer {
             return Ok(());
         }
 
-        self.progress(&format!("   Images to pull: {}", images_to_pull.join(", ")));
-        if !services_to_build.is_empty() {
-            let build_names: Vec<&str> = services_to_build.iter().map(|(n, _)| *n).collect();
-            self.progress(&format!("   Services to build: {}", build_names.join(", ")));
-        }
-
-        // Phase 1: Pull and save images locally
-        let temp_dir = std::env::temp_dir().join("iot2050-image-push");
-        if temp_dir.exists() {
-            std::fs::remove_dir_all(&temp_dir).map_err(|e| {
-                TelegrafError::ConfigError(format!("Failed to clean temp directory: {}", e))
+        // --- Phase 1: Pull, build, save ---
+        let output_dir = save_dir.clone().unwrap_or_else(|| {
+            std::env::temp_dir().join("iot2050-image-push")
+        });
+        if output_dir.exists() {
+            std::fs::remove_dir_all(&output_dir).map_err(|e| {
+                TelegrafError::ConfigError(format!("Failed to clean output directory: {}", e))
             })?;
         }
-        std::fs::create_dir_all(&temp_dir).map_err(|e| {
-            TelegrafError::ConfigError(format!("Failed to create temp directory: {}", e))
+        std::fs::create_dir_all(&output_dir).map_err(|e| {
+            TelegrafError::ConfigError(format!("Failed to create output directory: {}", e))
         })?;
 
         let mut tar_files: Vec<(String, std::path::PathBuf)> = Vec::new();
 
-        // Pull remote images
-        for image in &images_to_pull {
-            self.progress(&format!("📦 Pulling {} (platform: {})...", image, platform));
+        if load_dir.is_none() {
+            for image in &images_to_pull {
+                self.progress(&format!("📦 Pulling {} (platform: {})...", image, platform));
 
-            let pull_output = std::process::Command::new("docker")
-                .args(["pull", "--platform", &platform, image])
-                .output()
-                .map_err(|e| TelegrafError::ConfigError(format!("Failed to run docker pull: {}. Is Docker installed and running?", e)))?;
-
-            if !pull_output.status.success() {
-                let stderr = String::from_utf8_lossy(&pull_output.stderr);
-                return Err(TelegrafError::ConfigError(format!(
-                    "Failed to pull image {}: {}",
-                    image, stderr
-                )));
-            }
-
-            let safe_name = image.replace('/', "_").replace(':', "-");
-            let tar_path = temp_dir.join(format!("{}.tar", safe_name));
-
-            self.progress(&format!("💾 Saving {} to tar...", image));
-
-            let save_output = std::process::Command::new("docker")
-                .args(["save", "-o", tar_path.to_str().unwrap(), image])
-                .output()
-                .map_err(|e| TelegrafError::ConfigError(format!("Failed to run docker save: {}", e)))?;
-
-            if !save_output.status.success() {
-                let stderr = String::from_utf8_lossy(&save_output.stderr);
-                return Err(TelegrafError::ConfigError(format!(
-                    "Failed to save image {}: {}",
-                    image, stderr
-                )));
-            }
-
-            tar_files.push((image.to_string(), tar_path));
-        }
-
-        // Build custom images (api-service and control-service)
-        if !services_to_build.is_empty() {
-            for (service_name, dockerfile) in &services_to_build {
-                let image_tag = format!("{}:local", service_name);
-
-                self.progress(&format!("🔨 Building custom image {}...", image_tag));
-
-                let build_output = std::process::Command::new("docker")
-                    .args([
-                        "buildx",
-                        "build",
-                        "--platform",
-                        &platform,
-                        "-f",
-                        dockerfile,
-                        "--build-arg",
-                        &format!("TARGETARCH={}", arch),
-                        "-t",
-                        &image_tag,
-                        "--load",
-                        ".",
-                    ])
-                    .current_dir(&docker_context)
+                let pull_output = std::process::Command::new("docker")
+                    .args(["pull", "--platform", &platform, image])
                     .output()
-                    .map_err(|e| TelegrafError::ConfigError(format!("Failed to run docker buildx: {}", e)))?;
+                    .map_err(|e| TelegrafError::ConfigError(format!("Failed to run docker pull: {}. Is Docker installed and running?", e)))?;
 
-                if !build_output.status.success() {
-                    let stderr = String::from_utf8_lossy(&build_output.stderr);
+                if !pull_output.status.success() {
+                    let stderr = String::from_utf8_lossy(&pull_output.stderr);
                     return Err(TelegrafError::ConfigError(format!(
-                        "Failed to build {}: {}",
-                        image_tag, stderr
+                        "Failed to pull image {}: {}",
+                        image, stderr
                     )));
                 }
 
-                let tar_path = temp_dir.join(format!("{}.tar", service_name));
+                let safe_name = image.replace('/', "_").replace(':', "-");
+                let tar_path = output_dir.join(format!("{}.tar", safe_name));
 
-                self.progress(&format!("💾 Saving {} to tar...", image_tag));
+                self.progress(&format!("💾 Saving {} to tar...", image));
 
                 let save_output = std::process::Command::new("docker")
-                    .args(["save", "-o", tar_path.to_str().unwrap(), &image_tag])
+                    .args(["save", "-o", tar_path.to_str().unwrap(), image])
                     .output()
                     .map_err(|e| TelegrafError::ConfigError(format!("Failed to run docker save: {}", e)))?;
 
@@ -1239,17 +1204,108 @@ impl IoTDeployer {
                     let stderr = String::from_utf8_lossy(&save_output.stderr);
                     return Err(TelegrafError::ConfigError(format!(
                         "Failed to save image {}: {}",
-                        image_tag, stderr
+                        image, stderr
                     )));
                 }
 
-                tar_files.push((image_tag, tar_path));
+                tar_files.push((image.to_string(), tar_path));
             }
-        } else if skip_custom {
-            self.progress("⏭️  Skipping custom service images (--skip-custom)");
+
+            if !services_to_build.is_empty() {
+                for (service_name, dockerfile) in &services_to_build {
+                    let image_tag = format!("{}:local", service_name);
+
+                    self.progress(&format!("🔨 Building custom image {}...", image_tag));
+
+                    let build_output = std::process::Command::new("docker")
+                        .args([
+                            "buildx",
+                            "build",
+                            "--platform",
+                            &platform,
+                            "-f",
+                            dockerfile,
+                            "--build-arg",
+                            &format!("TARGETARCH={}", arch),
+                            "-t",
+                            &image_tag,
+                            "--load",
+                            ".",
+                        ])
+                        .current_dir(&docker_context)
+                        .output()
+                        .map_err(|e| TelegrafError::ConfigError(format!("Failed to run docker buildx: {}", e)))?;
+
+                    if !build_output.status.success() {
+                        let stderr = String::from_utf8_lossy(&build_output.stderr);
+                        return Err(TelegrafError::ConfigError(format!(
+                            "Failed to build {}: {}",
+                            image_tag, stderr
+                        )));
+                    }
+
+                    let tar_path = output_dir.join(format!("{}.tar", service_name));
+
+                    self.progress(&format!("💾 Saving {} to tar...", image_tag));
+
+                    let save_output = std::process::Command::new("docker")
+                        .args(["save", "-o", tar_path.to_str().unwrap(), &image_tag])
+                        .output()
+                        .map_err(|e| TelegrafError::ConfigError(format!("Failed to run docker save: {}", e)))?;
+
+                    if !save_output.status.success() {
+                        let stderr = String::from_utf8_lossy(&save_output.stderr);
+                        return Err(TelegrafError::ConfigError(format!(
+                            "Failed to save image {}: {}",
+                            image_tag, stderr
+                        )));
+                    }
+
+                    tar_files.push((image_tag, tar_path));
+                }
+            } else if skip_custom {
+                self.progress("⏭️  Skipping custom service images (--skip-custom)");
+            }
         }
 
-        // Phase 2: Transfer tar files to device
+        // Save-only mode: stop here
+        if save_dir.is_some() {
+            let file_count = tar_files.len();
+            self.progress(&format!(
+                "✅ Saved {} image tar(s) to {}",
+                file_count,
+                output_dir.display()
+            ));
+            return Ok(());
+        }
+
+        // --- If load_dir, discover tars from that directory ---
+        if load_dir.is_some() {
+            let dir = load_dir.as_ref().unwrap();
+            self.progress(&format!("📂 Loading tars from {}...", dir.display()));
+            for entry in std::fs::read_dir(dir).map_err(|e| {
+                TelegrafError::ConfigError(format!("Failed to read load directory: {}", e))
+            })? {
+                let entry = entry.map_err(|e| {
+                    TelegrafError::ConfigError(format!("Failed to read directory entry: {}", e))
+                })?;
+                let path = entry.path();
+                if path.extension().map(|e| e == "tar").unwrap_or(false) {
+                    let name = path.file_stem()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or("unknown")
+                        .to_string();
+                    tar_files.push((name, path));
+                }
+            }
+            if tar_files.is_empty() {
+                return Err(TelegrafError::ConfigError(
+                    "No .tar files found in the specified directory.".to_string(),
+                ));
+            }
+        }
+
+        // --- Phase 2: Transfer tar files to device ---
         self.progress("📤 Transferring images to device...");
 
         let session = self.create_ssh_session()?;
@@ -1294,7 +1350,7 @@ impl IoTDeployer {
             })?;
         }
 
-        // Phase 3: Load images on device
+        // --- Phase 3: Load images on device ---
         self.progress("📥 Loading images on device...");
 
         for (image_name, tar_path) in &tar_files {
@@ -1309,7 +1365,7 @@ impl IoTDeployer {
             self.run_command(&session, &load_cmd, &format!("Loading image {}", image_name))?;
         }
 
-        // Clean up tars on device (optional, saves disk space)
+        // Clean up tars on device
         self.progress("🧹 Cleaning up image tars on device...");
         let _ = self.run_command(
             &session,
@@ -1317,9 +1373,12 @@ impl IoTDeployer {
             "Removing temporary image tar files",
         );
 
-        // Clean up local temp files
-        self.progress("🧹 Cleaning up local temporary files...");
-        let _ = std::fs::remove_dir_all(&temp_dir);
+        // Clean up local temp files (only if we created them)
+        if load_dir.is_none() {
+            self.progress("🧹 Cleaning up local temporary files...");
+            let temp_dir = std::env::temp_dir().join("iot2050-image-push");
+            let _ = std::fs::remove_dir_all(temp_dir);
+        }
 
         let image_count = tar_files.len();
         self.progress(&format!(

--- a/src/backend/deployment.rs
+++ b/src/backend/deployment.rs
@@ -11,6 +11,79 @@ pub const GITHUB_REPO_OWNER: &str = "rlhf23";
 pub const GITHUB_REPO_NAME: &str = "iot2050-telegraf-config";
 pub const DEFAULT_BRANCH: &str = "master";
 
+pub const DOCKER_IMAGES: &[(&str, &str)] = &[
+    ("influxdb", "influxdb:2"),
+    ("telegraf", "telegraf:1.30"),
+    ("chronograf", "chronograf:1.10"),
+    ("nginx", "nginx:alpine"),
+    ("alpine", "alpine:3.19"),
+    ("grafana", "grafana/grafana:latest"),
+    ("prometheus", "prom/prometheus:latest"),
+];
+
+pub const MINIMAL_IMAGE_NAMES: &[&str] = &["influxdb", "telegraf", "chronograf", "nginx", "alpine"];
+
+pub const CUSTOM_SERVICES: &[(&str, &str)] = &[
+    ("api-service", "api-service/Dockerfile.prebuilt"),
+    ("control-service", "control-service/Dockerfile.prebuilt"),
+];
+
+pub fn filter_pull_images(minimal: bool, image_filter: &Option<Vec<String>>) -> Vec<&'static str> {
+    match image_filter {
+        Some(filter) => {
+            let filter_lower: Vec<String> = filter.iter().map(|s| s.to_lowercase()).collect();
+            DOCKER_IMAGES.iter()
+                .filter(|(name, _)| filter_lower.iter().any(|f| f == &name.to_lowercase()))
+                .map(|(_, tag)| *tag)
+                .collect()
+        }
+        None => {
+            if minimal {
+                DOCKER_IMAGES.iter()
+                    .filter(|(name, _)| MINIMAL_IMAGE_NAMES.contains(name))
+                    .map(|(_, tag)| *tag)
+                    .collect()
+            } else {
+                DOCKER_IMAGES.iter().map(|(_, tag)| *tag).collect()
+            }
+        }
+    }
+}
+
+pub fn filter_custom_services(skip_custom: bool, image_filter: &Option<Vec<String>>) -> Vec<(&'static str, &'static str)> {
+    if skip_custom {
+        return vec![];
+    }
+    match image_filter {
+        Some(filter) => {
+            let filter_lower: Vec<String> = filter.iter().map(|s| s.to_lowercase()).collect();
+            CUSTOM_SERVICES.iter()
+                .filter(|(name, _)| filter_lower.iter().any(|f| f == &name.to_lowercase()))
+                .cloned()
+                .collect()
+        }
+        None => CUSTOM_SERVICES.to_vec(),
+    }
+}
+
+pub fn image_tag_to_tar_filename(tag: &str) -> String {
+    format!("{}.tar", tag.replace('/', "_").replace(':', "-"))
+}
+
+pub fn validate_push_flags(
+    architecture: &Option<String>,
+    save_dir: &Option<std::path::PathBuf>,
+    load_dir: &Option<std::path::PathBuf>,
+) -> Result<(), String> {
+    if save_dir.is_some() && load_dir.is_some() {
+        return Err("Cannot use --save-dir and --load-dir together.".to_string());
+    }
+    if save_dir.is_some() && architecture.is_none() {
+        return Err("--architecture is required when using --save-dir (no device to auto-detect from).".to_string());
+    }
+    Ok(())
+}
+
 /// Sanitize a branch name for use in GitHub tarball URLs
 /// GitHub replaces '/' with '-' in archive names
 pub fn sanitize_branch_name(branch: &str) -> String {
@@ -1064,21 +1137,13 @@ impl IoTDeployer {
         save_dir: Option<std::path::PathBuf>,
         load_dir: Option<std::path::PathBuf>,
     ) -> Result<(), TelegrafError> {
-        if save_dir.is_some() && load_dir.is_some() {
-            return Err(TelegrafError::ConfigError(
-                "Cannot use --save-dir and --load-dir together.".to_string(),
-            ));
-        }
+        validate_push_flags(&architecture, &save_dir, &load_dir)
+            .map_err(TelegrafError::ConfigError)?;
 
         let (arch, needs_device) = if load_dir.is_some() {
             (architecture.unwrap_or_else(|| "arm64".to_string()), true)
         } else if save_dir.is_some() {
-            match architecture {
-                Some(a) => (a, false),
-                None => return Err(TelegrafError::ConfigError(
-                    "--architecture is required when using --save-dir (no device to auto-detect from).".to_string(),
-                )),
-            }
+            (architecture.unwrap_or_else(|| unreachable!()), false)
         } else {
             let a = match architecture {
                 Some(a) => {
@@ -1104,54 +1169,8 @@ impl IoTDeployer {
         }
         self.progress(&format!("   Docker context: {}", docker_context.display()));
 
-        let all_images: Vec<(&str, &str)> = vec![
-            ("influxdb", "influxdb:2"),
-            ("telegraf", "telegraf:1.30"),
-            ("chronograf", "chronograf:1.10"),
-            ("nginx", "nginx:alpine"),
-            ("alpine", "alpine:3.19"),
-            ("grafana", "grafana/grafana:latest"),
-            ("prometheus", "prom/prometheus:latest"),
-        ];
-
-        let minimal_names: &[&str] = &["influxdb", "telegraf", "chronograf", "nginx", "alpine"];
-
-        let images_to_pull: Vec<&str> = match &image_filter {
-            Some(filter) => {
-                let filter_lower: Vec<String> = filter.iter().map(|s| s.to_lowercase()).collect();
-                all_images.iter()
-                    .filter(|(name, _)| filter_lower.iter().any(|f| f == &name.to_lowercase()))
-                    .map(|(_, tag)| *tag)
-                    .collect()
-            }
-            None => {
-                if minimal {
-                    all_images.iter()
-                        .filter(|(name, _)| minimal_names.contains(name))
-                        .map(|(_, tag)| *tag)
-                        .collect()
-                } else {
-                    all_images.iter().map(|(_, tag)| *tag).collect()
-                }
-            }
-        };
-
-        let custom_services: Vec<(&str, &str)> = vec![
-            ("api-service", "api-service/Dockerfile.prebuilt"),
-            ("control-service", "control-service/Dockerfile.prebuilt"),
-        ];
-
-        let services_to_build: Vec<(&str, &str)> = if skip_custom || load_dir.is_some() {
-            vec![]
-        } else if let Some(filter) = &image_filter {
-            let filter_lower: Vec<String> = filter.iter().map(|s| s.to_lowercase()).collect();
-            custom_services.iter()
-                .filter(|(name, _)| filter_lower.iter().any(|f| f == &name.to_lowercase()))
-                .cloned()
-                .collect()
-        } else {
-            custom_services.clone()
-        };
+        let images_to_pull = filter_pull_images(minimal, &image_filter);
+        let services_to_build = filter_custom_services(skip_custom || load_dir.is_some(), &image_filter);
 
         if images_to_pull.is_empty() && services_to_build.is_empty() {
             self.progress("ℹ️  No images selected. Use --images to specify which images to push, or omit it to push all.");
@@ -1190,8 +1209,7 @@ impl IoTDeployer {
                     )));
                 }
 
-                let safe_name = image.replace('/', "_").replace(':', "-");
-                let tar_path = output_dir.join(format!("{}.tar", safe_name));
+                let tar_path = output_dir.join(image_tag_to_tar_filename(image));
 
                 self.progress(&format!("💾 Saving {} to tar...", image));
 

--- a/src/backend/deployment.rs
+++ b/src/backend/deployment.rs
@@ -1059,6 +1059,7 @@ impl IoTDeployer {
         &self,
         architecture: Option<String>,
         minimal: bool,
+        skip_custom: bool,
     ) -> Result<(), TelegrafError> {
         self.progress("🐳 Pushing Docker images to device...");
 
@@ -1144,61 +1145,65 @@ impl IoTDeployer {
         }
 
         // Build custom images (api-service and control-service)
-        let custom_services = [
-            ("api-service", "api-service/Dockerfile.prebuilt"),
-            ("control-service", "control-service/Dockerfile.prebuilt"),
-        ];
+        if !skip_custom {
+            let custom_services = [
+                ("api-service", "api-service/Dockerfile.prebuilt"),
+                ("control-service", "control-service/Dockerfile.prebuilt"),
+            ];
 
-        for (service_name, dockerfile) in &custom_services {
-            let image_tag = format!("{}:local", service_name);
+            for (service_name, dockerfile) in &custom_services {
+                let image_tag = format!("{}:local", service_name);
 
-            self.progress(&format!("🔨 Building custom image {}...", image_tag));
+                self.progress(&format!("🔨 Building custom image {}...", image_tag));
 
-            let build_output = std::process::Command::new("docker")
-                .args([
-                    "buildx",
-                    "build",
-                    "--platform",
-                    &platform,
-                    "-f",
-                    dockerfile,
-                    "--build-arg",
-                    &format!("TARGETARCH={}", arch),
-                    "-t",
-                    &image_tag,
-                    "--load",
-                    ".",
-                ])
-                .current_dir(&docker_context)
-                .output()
-                .map_err(|e| TelegrafError::ConfigError(format!("Failed to run docker buildx: {}", e)))?;
+                let build_output = std::process::Command::new("docker")
+                    .args([
+                        "buildx",
+                        "build",
+                        "--platform",
+                        &platform,
+                        "-f",
+                        dockerfile,
+                        "--build-arg",
+                        &format!("TARGETARCH={}", arch),
+                        "-t",
+                        &image_tag,
+                        "--load",
+                        ".",
+                    ])
+                    .current_dir(&docker_context)
+                    .output()
+                    .map_err(|e| TelegrafError::ConfigError(format!("Failed to run docker buildx: {}", e)))?;
 
-            if !build_output.status.success() {
-                let stderr = String::from_utf8_lossy(&build_output.stderr);
-                return Err(TelegrafError::ConfigError(format!(
-                    "Failed to build {}: {}",
-                    image_tag, stderr
-                )));
+                if !build_output.status.success() {
+                    let stderr = String::from_utf8_lossy(&build_output.stderr);
+                    return Err(TelegrafError::ConfigError(format!(
+                        "Failed to build {}: {}",
+                        image_tag, stderr
+                    )));
+                }
+
+                let tar_path = temp_dir.join(format!("{}.tar", service_name));
+
+                self.progress(&format!("💾 Saving {} to tar...", image_tag));
+
+                let save_output = std::process::Command::new("docker")
+                    .args(["save", "-o", tar_path.to_str().unwrap(), &image_tag])
+                    .output()
+                    .map_err(|e| TelegrafError::ConfigError(format!("Failed to run docker save: {}", e)))?;
+
+                if !save_output.status.success() {
+                    let stderr = String::from_utf8_lossy(&save_output.stderr);
+                    return Err(TelegrafError::ConfigError(format!(
+                        "Failed to save image {}: {}",
+                        image_tag, stderr
+                    )));
+                }
+
+                tar_files.push((image_tag, tar_path));
             }
-
-            let tar_path = temp_dir.join(format!("{}.tar", service_name));
-
-            self.progress(&format!("💾 Saving {} to tar...", image_tag));
-
-            let save_output = std::process::Command::new("docker")
-                .args(["save", "-o", tar_path.to_str().unwrap(), &image_tag])
-                .output()
-                .map_err(|e| TelegrafError::ConfigError(format!("Failed to run docker save: {}", e)))?;
-
-            if !save_output.status.success() {
-                let stderr = String::from_utf8_lossy(&save_output.stderr);
-                return Err(TelegrafError::ConfigError(format!(
-                    "Failed to save image {}: {}",
-                    image_tag, stderr
-                )));
-            }
-
-            tar_files.push((image_tag, tar_path));
+        } else {
+            self.progress("⏭️  Skipping custom service images (--skip-custom)");
         }
 
         // Phase 2: Transfer tar files to device

--- a/src/backend/deployment.rs
+++ b/src/backend/deployment.rs
@@ -1047,6 +1047,279 @@ impl PackageStatus {
 }
 
 impl IoTDeployer {
+    /// Push Docker images to the device for offline deployment.
+    ///
+    /// Pulls all required images locally (cross-arch if needed), builds custom
+    /// service images, saves them to tar files, transfers them to the device
+    /// via SFTP, and loads them into the device's Docker daemon.
+    ///
+    /// If `architecture` is None, it will be auto-detected from the device.
+    /// If `minimal` is true, Grafana and Prometheus images are skipped.
+    pub fn push_images(
+        &self,
+        architecture: Option<String>,
+        minimal: bool,
+    ) -> Result<(), TelegrafError> {
+        self.progress("🐳 Pushing Docker images to device...");
+
+        let arch = match architecture {
+            Some(a) => {
+                self.progress(&format!("   Using specified architecture: {}", a));
+                a
+            }
+            None => {
+                self.progress("   Detecting device architecture...");
+                self.detect_architecture()?
+            }
+        };
+
+        let platform = format!("linux/{}", arch);
+        let docker_context = self.find_docker_context()?;
+
+        self.progress(&format!("   Target platform: {}", platform));
+        self.progress(&format!("   Docker context: {}", docker_context.display()));
+
+        let mut images_to_pull = vec![
+            "influxdb:2",
+            "telegraf:1.30",
+            "chronograf:1.10",
+            "nginx:alpine",
+            "alpine:3.19",
+        ];
+
+        if !minimal {
+            images_to_pull.push("grafana/grafana:latest");
+            images_to_pull.push("prom/prometheus:latest");
+        }
+
+        // Phase 1: Pull and save images locally
+        let temp_dir = std::env::temp_dir().join("iot2050-image-push");
+        if temp_dir.exists() {
+            std::fs::remove_dir_all(&temp_dir).map_err(|e| {
+                TelegrafError::ConfigError(format!("Failed to clean temp directory: {}", e))
+            })?;
+        }
+        std::fs::create_dir_all(&temp_dir).map_err(|e| {
+            TelegrafError::ConfigError(format!("Failed to create temp directory: {}", e))
+        })?;
+
+        let mut tar_files: Vec<(String, std::path::PathBuf)> = Vec::new();
+
+        // Pull remote images
+        for image in &images_to_pull {
+            self.progress(&format!("📦 Pulling {} (platform: {})...", image, platform));
+
+            let pull_output = std::process::Command::new("docker")
+                .args(["pull", "--platform", &platform, image])
+                .output()
+                .map_err(|e| TelegrafError::ConfigError(format!("Failed to run docker pull: {}. Is Docker installed and running?", e)))?;
+
+            if !pull_output.status.success() {
+                let stderr = String::from_utf8_lossy(&pull_output.stderr);
+                return Err(TelegrafError::ConfigError(format!(
+                    "Failed to pull image {}: {}",
+                    image, stderr
+                )));
+            }
+
+            let safe_name = image.replace('/', "_").replace(':', "-");
+            let tar_path = temp_dir.join(format!("{}.tar", safe_name));
+
+            self.progress(&format!("💾 Saving {} to tar...", image));
+
+            let save_output = std::process::Command::new("docker")
+                .args(["save", "-o", tar_path.to_str().unwrap(), image])
+                .output()
+                .map_err(|e| TelegrafError::ConfigError(format!("Failed to run docker save: {}", e)))?;
+
+            if !save_output.status.success() {
+                let stderr = String::from_utf8_lossy(&save_output.stderr);
+                return Err(TelegrafError::ConfigError(format!(
+                    "Failed to save image {}: {}",
+                    image, stderr
+                )));
+            }
+
+            tar_files.push((image.to_string(), tar_path));
+        }
+
+        // Build custom images (api-service and control-service)
+        let custom_services = [
+            ("api-service", "api-service/Dockerfile.prebuilt"),
+            ("control-service", "control-service/Dockerfile.prebuilt"),
+        ];
+
+        for (service_name, dockerfile) in &custom_services {
+            let image_tag = format!("{}:local", service_name);
+
+            self.progress(&format!("🔨 Building custom image {}...", image_tag));
+
+            let build_output = std::process::Command::new("docker")
+                .args([
+                    "buildx",
+                    "build",
+                    "--platform",
+                    &platform,
+                    "-f",
+                    dockerfile,
+                    "--build-arg",
+                    &format!("TARGETARCH={}", arch),
+                    "-t",
+                    &image_tag,
+                    "--load",
+                    ".",
+                ])
+                .current_dir(&docker_context)
+                .output()
+                .map_err(|e| TelegrafError::ConfigError(format!("Failed to run docker buildx: {}", e)))?;
+
+            if !build_output.status.success() {
+                let stderr = String::from_utf8_lossy(&build_output.stderr);
+                return Err(TelegrafError::ConfigError(format!(
+                    "Failed to build {}: {}",
+                    image_tag, stderr
+                )));
+            }
+
+            let tar_path = temp_dir.join(format!("{}.tar", service_name));
+
+            self.progress(&format!("💾 Saving {} to tar...", image_tag));
+
+            let save_output = std::process::Command::new("docker")
+                .args(["save", "-o", tar_path.to_str().unwrap(), &image_tag])
+                .output()
+                .map_err(|e| TelegrafError::ConfigError(format!("Failed to run docker save: {}", e)))?;
+
+            if !save_output.status.success() {
+                let stderr = String::from_utf8_lossy(&save_output.stderr);
+                return Err(TelegrafError::ConfigError(format!(
+                    "Failed to save image {}: {}",
+                    image_tag, stderr
+                )));
+            }
+
+            tar_files.push((image_tag, tar_path));
+        }
+
+        // Phase 2: Transfer tar files to device
+        self.progress("📤 Transferring images to device...");
+
+        let session = self.create_ssh_session()?;
+
+        self.run_command(
+            &session,
+            "mkdir -p ~/monitoring/images",
+            "Creating images directory on device",
+        )?;
+
+        let sftp = session.sftp().map_err(|e| {
+            TelegrafError::ConfigError(format!("Failed to create SFTP session: {}", e))
+        })?;
+
+        let remote_base = Path::new("/home")
+            .join(self.user())
+            .join("monitoring")
+            .join("images");
+
+        for (image_name, tar_path) in &tar_files {
+            let file_size = std::fs::metadata(tar_path)
+                .map(|m| m.len())
+                .unwrap_or(0);
+            let size_mb = file_size as f64 / (1024.0 * 1024.0);
+            self.progress(&format!(
+                "   Uploading {} ({:.1} MB)...",
+                image_name, size_mb
+            ));
+
+            let remote_path = remote_base.join(tar_path.file_name().unwrap());
+
+            let mut local_file = std::fs::File::open(tar_path).map_err(|e| {
+                TelegrafError::ConfigError(format!("Failed to open tar file: {}", e))
+            })?;
+
+            let mut remote_file = sftp.create(&remote_path).map_err(|e| {
+                TelegrafError::ConfigError(format!("Failed to create remote file: {}", e))
+            })?;
+
+            std::io::copy(&mut local_file, &mut remote_file).map_err(|e| {
+                TelegrafError::ConfigError(format!("Failed to upload image tar: {}", e))
+            })?;
+        }
+
+        // Phase 3: Load images on device
+        self.progress("📥 Loading images on device...");
+
+        for (image_name, tar_path) in &tar_files {
+            let tar_filename = tar_path.file_name().unwrap().to_str().unwrap();
+            self.progress(&format!("   Loading {}...", image_name));
+
+            let load_cmd = format!(
+                "docker load -i ~/monitoring/images/{}",
+                tar_filename
+            );
+
+            self.run_command(&session, &load_cmd, &format!("Loading image {}", image_name))?;
+        }
+
+        // Clean up tars on device (optional, saves disk space)
+        self.progress("🧹 Cleaning up image tars on device...");
+        let _ = self.run_command(
+            &session,
+            "rm -rf ~/monitoring/images",
+            "Removing temporary image tar files",
+        );
+
+        // Clean up local temp files
+        self.progress("🧹 Cleaning up local temporary files...");
+        let _ = std::fs::remove_dir_all(&temp_dir);
+
+        let image_count = tar_files.len();
+        self.progress(&format!(
+            "✅ Successfully pushed {} images to device!",
+            image_count
+        ));
+        Ok(())
+    }
+
+    /// Find the docker context directory by looking for docker-compose.yml
+    fn find_docker_context(&self) -> Result<std::path::PathBuf, TelegrafError> {
+        let exe_dir = std::env::current_exe()
+            .map_err(|e| TelegrafError::ConfigError(format!("Failed to get exe path: {}", e)))?;
+        let exe_dir = exe_dir.parent().ok_or_else(|| {
+            TelegrafError::ConfigError("Failed to determine exe directory".to_string())
+        })?;
+
+        let mut search_dir = exe_dir.to_path_buf();
+        loop {
+            let candidate = search_dir.join("docker").join("docker-compose.yml");
+            if candidate.exists() {
+                return Ok(search_dir.join("docker"));
+            }
+            if !search_dir.pop() {
+                break;
+            }
+        }
+
+        let cwd = std::env::current_dir().map_err(|e| {
+            TelegrafError::ConfigError(format!("Failed to get current directory: {}", e))
+        })?;
+
+        let mut search_dir = cwd;
+        loop {
+            let candidate = search_dir.join("docker").join("docker-compose.yml");
+            if candidate.exists() {
+                return Ok(search_dir.join("docker"));
+            }
+            if !search_dir.pop() {
+                break;
+            }
+        }
+
+        Err(TelegrafError::ConfigError(
+            "Could not find docker/ directory with docker-compose.yml. Run push-images from the project root.".to_string()
+        ))
+    }
+
     /// Recursively upload a directory via SFTP
     fn upload_directory_sftp(
         &self,

--- a/src/backend/deployment_test.rs
+++ b/src/backend/deployment_test.rs
@@ -3,8 +3,11 @@
 use super::deployment::{
     generate_repo_url, get_extracted_dir_name, sanitize_branch_name, DEFAULT_BRANCH,
     GITHUB_REPO_NAME, GITHUB_REPO_OWNER,
+    filter_pull_images, filter_custom_services, image_tag_to_tar_filename,
+    validate_push_flags, DOCKER_IMAGES, MINIMAL_IMAGE_NAMES, CUSTOM_SERVICES,
 };
 use super::deployment::{DeploymentConfig, IoTDeployer};
+use std::path::PathBuf;
 
 #[test]
 fn deployment_config_builder_methods_work() {
@@ -33,7 +36,6 @@ fn deployment_config_with_git_branch() {
 fn iot_deployer_can_be_constructed() {
     let config = DeploymentConfig::new("localhost".to_string(), "tester".to_string());
     let deployer = IoTDeployer::new(config.clone());
-    // Just check construction; config should match
     assert_eq!(deployer.host(), config.host);
     assert_eq!(deployer.user(), config.user);
 }
@@ -96,7 +98,6 @@ fn sanitize_branch_name_simple() {
 
 #[test]
 fn sanitize_branch_name_with_slashes() {
-    // GitHub replaces '/' with '-' in archive names
     assert_eq!(sanitize_branch_name("feature/login"), "feature-login");
     assert_eq!(
         sanitize_branch_name("feature/user/dashboard"),
@@ -107,7 +108,6 @@ fn sanitize_branch_name_with_slashes() {
 
 #[test]
 fn sanitize_branch_name_with_special_chars() {
-    // Branches with underscores, dots, etc. should be preserved
     assert_eq!(sanitize_branch_name("feature_user"), "feature_user");
     assert_eq!(sanitize_branch_name("release-1.0"), "release-1.0");
     assert_eq!(sanitize_branch_name("v1.2.3"), "v1.2.3");
@@ -127,7 +127,6 @@ fn generate_repo_url_master_branch() {
 fn generate_repo_url_feature_branch() {
     let url = generate_repo_url("feature/my-feature");
     assert!(url.contains("feature/my-feature.tar.gz"));
-    // URL contains the raw branch name (not sanitized)
     assert!(url.contains("refs/heads/feature/my-feature.tar.gz"));
 }
 
@@ -143,7 +142,6 @@ fn generate_repo_url_format() {
 
 #[test]
 fn get_extracted_dir_name_simple() {
-    // Simple branch names stay as-is
     let dir = get_extracted_dir_name("master");
     assert_eq!(dir, format!("{}-master", GITHUB_REPO_NAME));
 
@@ -153,7 +151,6 @@ fn get_extracted_dir_name_simple() {
 
 #[test]
 fn get_extracted_dir_name_with_slashes() {
-    // GitHub sanitizes slashes in extracted directory names
     let dir = get_extracted_dir_name("feature/login");
     assert_eq!(dir, format!("{}-feature-login", GITHUB_REPO_NAME));
 
@@ -169,10 +166,7 @@ fn default_branch_constant() {
 #[test]
 fn iot_deployer_uses_default_branch_when_none() {
     let config = DeploymentConfig::new("host.example.com".to_string(), "user".to_string());
-    let deployer = IoTDeployer::new(config);
-    // Internally, deployer should use DEFAULT_BRANCH when no branch is specified
-    // We can't directly access the branch field, but we can verify the URL is correct
-    // by checking that generate_repo_url uses the right format
+    let _deployer = IoTDeployer::new(config);
     let expected_url = generate_repo_url(DEFAULT_BRANCH);
     let actual_url = generate_repo_url("master");
     assert_eq!(expected_url, actual_url);
@@ -180,21 +174,15 @@ fn iot_deployer_uses_default_branch_when_none() {
 
 #[test]
 fn iot_deployer_default_branch_url_format() {
-    // Verify the generated URL matches expected pattern for default branch
     let config = DeploymentConfig::new("host.example.com".to_string(), "user".to_string());
     let _deployer = IoTDeployer::new(config);
-
-    // The URL should point to the master branch tarball
     let url = generate_repo_url(DEFAULT_BRANCH);
     assert!(url.ends_with(&format!("{}.tar.gz", DEFAULT_BRANCH)));
 }
 
 #[test]
 fn branch_url_components() {
-    // Verify all URL components are present and correct
     let url = generate_repo_url("test-branch");
-
-    // Check URL structure: https://github.com/{owner}/{repo}/archive/refs/heads/{branch}.tar.gz
     assert!(url.starts_with("https://github.com/"));
     assert!(url.contains(&format!("/{}/", GITHUB_REPO_OWNER)));
     assert!(url.contains(&format!("/{}/", GITHUB_REPO_NAME)));
@@ -202,5 +190,185 @@ fn branch_url_components() {
     assert!(url.ends_with(".tar.gz"));
 }
 
-// TODO: For full coverage, refactor IoTDeployer to allow injecting a mock Session.
-// This will enable testing of run_command, test_connection, etc., without real SSH.
+// ============================================================================
+// Image filtering tests
+// ============================================================================
+
+#[test]
+fn filter_pull_images_returns_all_when_no_filter() {
+    let images = filter_pull_images(false, &None);
+    assert_eq!(images.len(), DOCKER_IMAGES.len());
+    assert!(images.contains(&"influxdb:2"));
+    assert!(images.contains(&"grafana/grafana:latest"));
+    assert!(images.contains(&"prom/prometheus:latest"));
+}
+
+#[test]
+fn filter_pull_images_minimal_excludes_full_profile() {
+    let images = filter_pull_images(true, &None);
+    assert_eq!(images.len(), MINIMAL_IMAGE_NAMES.len());
+    assert!(images.contains(&"influxdb:2"));
+    assert!(images.contains(&"chronograf:1.10"));
+    assert!(!images.contains(&"grafana/grafana:latest"));
+    assert!(!images.contains(&"prom/prometheus:latest"));
+}
+
+#[test]
+fn filter_pull_images_with_specific_filter() {
+    let filter = Some(vec!["chronograf".to_string(), "influxdb".to_string()]);
+    let images = filter_pull_images(false, &filter);
+    assert_eq!(images.len(), 2);
+    assert!(images.contains(&"chronograf:1.10"));
+    assert!(images.contains(&"influxdb:2"));
+}
+
+#[test]
+fn filter_pull_images_filter_case_insensitive() {
+    let filter = Some(vec!["Chronograf".to_string(), "INFLUXDB".to_string()]);
+    let images = filter_pull_images(false, &filter);
+    assert_eq!(images.len(), 2);
+    assert!(images.contains(&"chronograf:1.10"));
+    assert!(images.contains(&"influxdb:2"));
+}
+
+#[test]
+fn filter_pull_images_filter_overrides_minimal() {
+    // If you explicitly request grafana with --images, you get it even with --minimal
+    let filter = Some(vec!["grafana".to_string()]);
+    let images = filter_pull_images(true, &filter);
+    assert_eq!(images.len(), 1);
+    assert!(images.contains(&"grafana/grafana:latest"));
+}
+
+#[test]
+fn filter_pull_images_empty_filter_returns_nothing() {
+    let filter = Some(vec![]);
+    let images = filter_pull_images(false, &filter);
+    assert!(images.is_empty());
+}
+
+#[test]
+fn filter_pull_images_unknown_name_returns_nothing() {
+    let filter = Some(vec!["nonexistent".to_string()]);
+    let images = filter_pull_images(false, &filter);
+    assert!(images.is_empty());
+}
+
+#[test]
+fn filter_custom_services_default() {
+    let services = filter_custom_services(false, &None);
+    assert_eq!(services.len(), CUSTOM_SERVICES.len());
+    assert!(services.iter().any(|(n, _)| *n == "api-service"));
+    assert!(services.iter().any(|(n, _)| *n == "control-service"));
+}
+
+#[test]
+fn filter_custom_services_skip() {
+    let services = filter_custom_services(true, &None);
+    assert!(services.is_empty());
+}
+
+#[test]
+fn filter_custom_services_with_image_filter() {
+    let filter = Some(vec!["api-service".to_string()]);
+    let services = filter_custom_services(false, &filter);
+    assert_eq!(services.len(), 1);
+    assert_eq!(services[0].0, "api-service");
+}
+
+#[test]
+fn filter_custom_services_filter_case_insensitive() {
+    let filter = Some(vec!["API-Service".to_string()]);
+    let services = filter_custom_services(false, &filter);
+    assert_eq!(services.len(), 1);
+    assert_eq!(services[0].0, "api-service");
+}
+
+#[test]
+fn filter_custom_services_empty_filter_returns_nothing() {
+    let filter = Some(vec![]);
+    let services = filter_custom_services(false, &filter);
+    assert!(services.is_empty());
+}
+
+#[test]
+fn filter_custom_services_skip_overrides_filter() {
+    // skip_custom=true always returns empty even with filter
+    let filter = Some(vec!["api-service".to_string()]);
+    let services = filter_custom_services(true, &filter);
+    assert!(services.is_empty());
+}
+
+// ============================================================================
+// Tar filename tests
+// ============================================================================
+
+#[test]
+fn image_tag_to_tar_filename_simple() {
+    assert_eq!(image_tag_to_tar_filename("influxdb:2"), "influxdb-2.tar");
+    assert_eq!(image_tag_to_tar_filename("nginx:alpine"), "nginx-alpine.tar");
+    assert_eq!(image_tag_to_tar_filename("telegraf:1.30"), "telegraf-1.30.tar");
+}
+
+#[test]
+fn image_tag_to_tar_filename_with_registry() {
+    assert_eq!(image_tag_to_tar_filename("grafana/grafana:latest"), "grafana_grafana-latest.tar");
+    assert_eq!(image_tag_to_tar_filename("prom/prometheus:latest"), "prom_prometheus-latest.tar");
+}
+
+#[test]
+fn image_tag_to_tar_filename_no_tag() {
+    assert_eq!(image_tag_to_tar_filename("alpine:3.19"), "alpine-3.19.tar");
+}
+
+#[test]
+fn image_tag_to_tar_filename_custom_service() {
+    assert_eq!(image_tag_to_tar_filename("api-service:local"), "api-service-local.tar");
+    assert_eq!(image_tag_to_tar_filename("control-service:local"), "control-service-local.tar");
+}
+
+// ============================================================================
+// Flag validation tests
+// ============================================================================
+
+#[test]
+fn validate_push_flags_normal() {
+    assert!(validate_push_flags(&None, &None, &None).is_ok());
+}
+
+#[test]
+fn validate_push_flags_save_dir_requires_architecture() {
+    let result = validate_push_flags(&None, &Some(PathBuf::from("/tmp/images")), &None);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("--architecture is required"));
+}
+
+#[test]
+fn validate_push_flags_save_dir_with_architecture() {
+    let result = validate_push_flags(&Some("arm64".to_string()), &Some(PathBuf::from("/tmp/images")), &None);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn validate_push_flags_cannot_use_both() {
+    let result = validate_push_flags(
+        &Some("arm64".to_string()),
+        &Some(PathBuf::from("/tmp/images")),
+        &Some(PathBuf::from("/tmp/images")),
+    );
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("Cannot use --save-dir and --load-dir together"));
+}
+
+#[test]
+fn validate_push_flags_load_dir_without_architecture() {
+    // load-dir defaults to arm64 if no architecture given
+    let result = validate_push_flags(&None, &None, &Some(PathBuf::from("/tmp/images")));
+    assert!(result.is_ok());
+}
+
+#[test]
+fn validate_push_flags_load_dir_with_architecture() {
+    let result = validate_push_flags(&Some("amd64".to_string()), &None, &Some(PathBuf::from("/tmp/images")));
+    assert!(result.is_ok());
+}

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -129,6 +129,19 @@ fn handle_device_command(matches: &clap::ArgMatches) {
 
             wrap_up(0);
         }
+        Some(("push-images", sub_matches)) => {
+            let config = create_deployment_config(sub_matches);
+            let minimal = sub_matches.get_flag("minimal");
+            let arch_arg = sub_matches.get_one::<String>("architecture").unwrap();
+            let architecture = if arch_arg == "auto" { None } else { Some(arch_arg.clone()) };
+            let deployer = IoTDeployer::new(config).with_minimal(minimal);
+
+            if let Err(e) = deployer.push_images(architecture, minimal) {
+                exit_with_error(format!("Push images failed: {}", e));
+            }
+
+            wrap_up(0);
+        }
         Some(("stop", sub_matches)) => {
             let config = create_deployment_config(sub_matches);
             let deployer = IoTDeployer::new(config);
@@ -716,6 +729,16 @@ fn main() {
                         .arg(clap::Arg::new("iot_username").short('u').long("iot-username").default_value(env!("DEFAULT_IOT_USERNAME")).help("SSH username"))
                         .arg(clap::Arg::new("iot_password").short('p').long("iot-password").default_value(env!("DEFAULT_IOT_PASSWORD")).help("SSH password"))
                         .arg(clap::Arg::new("key_file").short('k').long("key-file").help("SSH private key file path"))
+                )
+                .subcommand(
+                    Command::new("push-images")
+                        .about("Push Docker images to device for offline deployment")
+                        .arg(clap::Arg::new("host").help("Device IP address").default_value(env!("DEFAULT_IOT_IP")))
+                        .arg(clap::Arg::new("iot_username").short('u').long("iot-username").default_value(env!("DEFAULT_IOT_USERNAME")).help("SSH username"))
+                        .arg(clap::Arg::new("iot_password").short('p').long("iot-password").default_value(env!("DEFAULT_IOT_PASSWORD")).help("SSH password"))
+                        .arg(clap::Arg::new("key_file").short('k').long("key-file").help("SSH private key file path"))
+                        .arg(clap::Arg::new("architecture").short('a').long("architecture").default_value("auto").help("Target architecture (auto, arm64, amd64). Auto-detects from device if not specified."))
+                        .arg(clap::Arg::new("minimal").short('m').long("minimal").action(clap::ArgAction::SetTrue).help("Push minimal images only (skip Grafana and Prometheus)"))
                 )
         )
         .subcommand(

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -138,9 +138,11 @@ fn handle_device_command(matches: &clap::ArgMatches) {
             let image_filter = sub_matches.get_one::<String>("images").map(|s| {
                 s.split(',').map(|i| i.trim().to_string()).filter(|i| !i.is_empty()).collect()
             });
+            let save_dir = sub_matches.get_one::<String>("save_dir").map(|s| std::path::PathBuf::from(s));
+            let load_dir = sub_matches.get_one::<String>("load_dir").map(|s| std::path::PathBuf::from(s));
             let deployer = IoTDeployer::new(config).with_minimal(minimal);
 
-            if let Err(e) = deployer.push_images(architecture, minimal, skip_custom, image_filter) {
+            if let Err(e) = deployer.push_images(architecture, minimal, skip_custom, image_filter, save_dir, load_dir) {
                 exit_with_error(format!("Push images failed: {}", e));
             }
 
@@ -745,6 +747,8 @@ fn main() {
                         .arg(clap::Arg::new("minimal").short('m').long("minimal").action(clap::ArgAction::SetTrue).help("Push minimal images only (skip Grafana and Prometheus)"))
                         .arg(clap::Arg::new("skip_custom").long("skip-custom").action(clap::ArgAction::SetTrue).help("Skip building and pushing custom service images (api-service, control-service)"))
                         .arg(clap::Arg::new("images").long("images").help("Comma-separated list of specific images to push (e.g. chronograf,influxdb). Valid names: influxdb, telegraf, chronograf, nginx, alpine, grafana, prometheus, api-service, control-service"))
+                        .arg(clap::Arg::new("save_dir").long("save-dir").help("Save image tars to this directory instead of pushing to device (airgap: step 1). Requires --architecture"))
+                        .arg(clap::Arg::new("load_dir").long("load-dir").help("Load image tars from this directory and push to device (airgap: step 2). No Docker needed on host"))
                 )
         )
         .subcommand(

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -132,11 +132,12 @@ fn handle_device_command(matches: &clap::ArgMatches) {
         Some(("push-images", sub_matches)) => {
             let config = create_deployment_config(sub_matches);
             let minimal = sub_matches.get_flag("minimal");
+            let skip_custom = sub_matches.get_flag("skip_custom");
             let arch_arg = sub_matches.get_one::<String>("architecture").unwrap();
             let architecture = if arch_arg == "auto" { None } else { Some(arch_arg.clone()) };
             let deployer = IoTDeployer::new(config).with_minimal(minimal);
 
-            if let Err(e) = deployer.push_images(architecture, minimal) {
+            if let Err(e) = deployer.push_images(architecture, minimal, skip_custom) {
                 exit_with_error(format!("Push images failed: {}", e));
             }
 
@@ -739,6 +740,7 @@ fn main() {
                         .arg(clap::Arg::new("key_file").short('k').long("key-file").help("SSH private key file path"))
                         .arg(clap::Arg::new("architecture").short('a').long("architecture").default_value("auto").help("Target architecture (auto, arm64, amd64). Auto-detects from device if not specified."))
                         .arg(clap::Arg::new("minimal").short('m').long("minimal").action(clap::ArgAction::SetTrue).help("Push minimal images only (skip Grafana and Prometheus)"))
+                        .arg(clap::Arg::new("skip_custom").long("skip-custom").action(clap::ArgAction::SetTrue).help("Skip building and pushing custom service images (api-service, control-service)"))
                 )
         )
         .subcommand(

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -135,9 +135,12 @@ fn handle_device_command(matches: &clap::ArgMatches) {
             let skip_custom = sub_matches.get_flag("skip_custom");
             let arch_arg = sub_matches.get_one::<String>("architecture").unwrap();
             let architecture = if arch_arg == "auto" { None } else { Some(arch_arg.clone()) };
+            let image_filter = sub_matches.get_one::<String>("images").map(|s| {
+                s.split(',').map(|i| i.trim().to_string()).filter(|i| !i.is_empty()).collect()
+            });
             let deployer = IoTDeployer::new(config).with_minimal(minimal);
 
-            if let Err(e) = deployer.push_images(architecture, minimal, skip_custom) {
+            if let Err(e) = deployer.push_images(architecture, minimal, skip_custom, image_filter) {
                 exit_with_error(format!("Push images failed: {}", e));
             }
 
@@ -741,6 +744,7 @@ fn main() {
                         .arg(clap::Arg::new("architecture").short('a').long("architecture").default_value("auto").help("Target architecture (auto, arm64, amd64). Auto-detects from device if not specified."))
                         .arg(clap::Arg::new("minimal").short('m').long("minimal").action(clap::ArgAction::SetTrue).help("Push minimal images only (skip Grafana and Prometheus)"))
                         .arg(clap::Arg::new("skip_custom").long("skip-custom").action(clap::ArgAction::SetTrue).help("Skip building and pushing custom service images (api-service, control-service)"))
+                        .arg(clap::Arg::new("images").long("images").help("Comma-separated list of specific images to push (e.g. chronograf,influxdb). Valid names: influxdb, telegraf, chronograf, nginx, alpine, grafana, prometheus, api-service, control-service"))
                 )
         )
         .subcommand(

--- a/src/bin/tui.rs
+++ b/src/bin/tui.rs
@@ -100,6 +100,7 @@ enum DeviceActionField {
     Provision,
     Setup,
     Update,
+    PushImages,
     Start,
     Stop,
     Status,
@@ -110,7 +111,7 @@ enum DeviceActionField {
 
 impl DeviceActionField {
     fn count() -> usize {
-        9
+        10
     }
 
     fn from_index(index: usize) -> Self {
@@ -118,12 +119,13 @@ impl DeviceActionField {
             0 => Self::Provision,
             1 => Self::Setup,
             2 => Self::Update,
-            3 => Self::Start,
-            4 => Self::Stop,
-            5 => Self::Status,
-            6 => Self::Backup,
-            7 => Self::Restore,
-            8 => Self::SyncTime,
+            3 => Self::PushImages,
+            4 => Self::Start,
+            5 => Self::Stop,
+            6 => Self::Status,
+            7 => Self::Backup,
+            8 => Self::Restore,
+            9 => Self::SyncTime,
             _ => Self::Provision,
         }
     }
@@ -136,11 +138,12 @@ enum DeviceConfigField {
     GitBranch,
     Minimal,
     LocalTransfer,
+    SkipCustom,
 }
 
 impl DeviceConfigField {
     fn count() -> usize {
-        5
+        6
     }
 
     fn from_index(index: usize) -> Self {
@@ -150,6 +153,7 @@ impl DeviceConfigField {
             2 => Self::GitBranch,
             3 => Self::Minimal,
             4 => Self::LocalTransfer,
+            5 => Self::SkipCustom,
             _ => Self::DeviceName,
         }
     }
@@ -268,6 +272,7 @@ struct App {
     git_branch: String,
     minimal: bool,
     local_transfer: bool,
+    skip_custom: bool,
 
     // Confirmation for destructive operations
     pending_confirmation: Option<String>,
@@ -326,6 +331,7 @@ impl App {
             git_branch: "master".to_string(),
             minimal: false,
             local_transfer: false,
+            skip_custom: false,
             pending_confirmation: None,
         };
 
@@ -1161,6 +1167,26 @@ fn add_status_message(&mut self, message: String) {
         self.add_status_message("⚠️ Restore requires an archive path. Use the CLI for restore with a specific archive file.".to_string());
     }
 
+    fn device_push_images(&mut self) {
+        if self.worker.is_none() {
+            self.add_status_message("❌ Worker not available".to_string());
+            return;
+        }
+        self.start_working();
+        self.add_status_message("🐳 Pushing Docker images to device...".to_string());
+        if let Some(worker) = &self.worker {
+            let config = self.build_deployment_config();
+            if let Err(e) = worker.send_command(WorkerCommand::DevicePushImages {
+                config,
+                minimal: self.minimal,
+                skip_custom: self.skip_custom,
+            }) {
+                self.add_status_message(format!("❌ Failed to send command: {}", e));
+                self.stop_working();
+            }
+        }
+    }
+
     fn build_deployment_config(&self) -> DeploymentConfig {
         let host = self.config.iot_host.clone();
         let user = self.config.iot_username.clone();
@@ -1636,6 +1662,13 @@ fn handle_device_input(app: &mut App, key: KeyCode) {
                             if app.local_transfer { "enabled" } else { "disabled" }
                         ));
                     }
+                    DeviceConfigField::SkipCustom => {
+                        app.skip_custom = !app.skip_custom;
+                        app.add_status_message(format!(
+                            "Skip custom images: {}",
+                            if app.skip_custom { "enabled" } else { "disabled" }
+                        ));
+                    }
                 }
             }
             _ => {}
@@ -1658,6 +1691,7 @@ fn handle_device_input(app: &mut App, key: KeyCode) {
                     DeviceActionField::Provision => app.device_provision(),
                     DeviceActionField::Setup => app.device_setup(),
                     DeviceActionField::Update => app.device_update(),
+                    DeviceActionField::PushImages => app.device_push_images(),
                     DeviceActionField::Start => app.device_start(),
                     DeviceActionField::Stop => app.device_stop(),
                     DeviceActionField::Status => app.device_status(),
@@ -1669,6 +1703,7 @@ fn handle_device_input(app: &mut App, key: KeyCode) {
             KeyCode::Char('p') => app.device_provision(),
             KeyCode::Char('s') => app.device_setup(),
             KeyCode::Char('u') => app.device_update(),
+            KeyCode::Char('i') => app.device_push_images(),
             KeyCode::Char('g') => app.device_start(),
             KeyCode::Char('v') => app.device_stop_with_volumes(),
             KeyCode::Char('n') => {
@@ -2290,6 +2325,11 @@ fn render_device_tab(f: &mut Frame, app: &mut App, area: Rect) {
             action_highlight && matches!(selected_action, DeviceActionField::Update),
             "u",
         ),
+        render_action_item(
+            "🐳 Push Images",
+            action_highlight && matches!(selected_action, DeviceActionField::PushImages),
+            "i",
+        ),
         Line::from(""),
         Line::from("Service Control:"),
         render_action_item(
@@ -2337,6 +2377,7 @@ fn render_device_tab(f: &mut Frame, app: &mut App, area: Rect) {
     // Configuration panel
     let minimal_status = if app.minimal { "Enabled" } else { "Disabled" };
     let local_transfer_status = if app.local_transfer { "Enabled" } else { "Disabled" };
+    let skip_custom_status = if app.skip_custom { "Enabled" } else { "Disabled" };
 
     let device_name_display = if app.device_name.is_empty() {
         "(random name)"
@@ -2370,6 +2411,9 @@ fn render_device_tab(f: &mut Frame, app: &mut App, area: Rect) {
         Line::from(format!("{} Local Transfer: {}",
             if config_highlight && matches!(selected_config, DeviceConfigField::LocalTransfer) { "►" } else { " " },
             local_transfer_status)),
+        Line::from(format!("{} Skip Custom Images: {}",
+            if config_highlight && matches!(selected_config, DeviceConfigField::SkipCustom) { "►" } else { " " },
+            skip_custom_status)),
         Line::from(""),
         Line::from("IoT Connection (from IoT Config tab):"),
         Line::from(format!("  Host: {}", app.config.iot_host)),

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -663,7 +663,7 @@ impl WorkerHandle {
                             });
                             let deployer = IoTDeployer::new(config).with_minimal(minimal).with_progress_sender(progress_tx);
                             let result = deployer
-                                .push_images(None, minimal, skip_custom, None)
+                                .push_images(None, minimal, skip_custom, None, None, None)
                                 .map(|_| WorkerResponse::SshCommandOutput(
                                     "Push images completed successfully".to_string(),
                                 ))

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -663,7 +663,7 @@ impl WorkerHandle {
                             });
                             let deployer = IoTDeployer::new(config).with_minimal(minimal).with_progress_sender(progress_tx);
                             let result = deployer
-                                .push_images(None, minimal, skip_custom)
+                                .push_images(None, minimal, skip_custom, None)
                                 .map(|_| WorkerResponse::SshCommandOutput(
                                     "Push images completed successfully".to_string(),
                                 ))

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -97,6 +97,11 @@ pub enum WorkerCommand {
         archive_path: String,
         force: bool,
     },
+    DevicePushImages {
+        config: DeploymentConfig,
+        minimal: bool,
+        skip_custom: bool,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -642,6 +647,27 @@ impl WorkerHandle {
                                     "Restore completed successfully".to_string(),
                                 ))
                                 .unwrap_or_else(|e| WorkerResponse::SshError(format!("Restore failed: {}", e)));
+                            let _ = response_sender.send(result);
+                        });
+                        continue;
+                    }
+                    WorkerCommand::DevicePushImages { config, minimal, skip_custom } => {
+                        let response_sender = response_sender.clone();
+                        std::thread::spawn(move || {
+                            let (progress_tx, progress_rx) = std::sync::mpsc::channel::<String>();
+                            let sender_clone = response_sender.clone();
+                            std::thread::spawn(move || {
+                                while let Ok(msg) = progress_rx.recv() {
+                                    let _ = sender_clone.send(WorkerResponse::ProgressUpdate(msg));
+                                }
+                            });
+                            let deployer = IoTDeployer::new(config).with_minimal(minimal).with_progress_sender(progress_tx);
+                            let result = deployer
+                                .push_images(None, minimal, skip_custom)
+                                .map(|_| WorkerResponse::SshCommandOutput(
+                                    "Push images completed successfully".to_string(),
+                                ))
+                                .unwrap_or_else(|e| WorkerResponse::SshError(format!("Push images failed: {}", e)));
                             let _ = response_sender.send(result);
                         });
                         continue;


### PR DESCRIPTION
# Add `device push-images` command for offline Docker image deployment

## Problem

Deployed IoT devices need internet to pull Docker images. Devices on isolated networks can't update images (e.g., chronograf added to compose stack).

## Solution

New `push-images` command — pulls, builds, transfers, and loads images over SSH for fully offline deployment.

> **Note:** The host machine running `push-images` needs Docker installed and running (rootless Docker works fine).

### CLI

    sie_generate_config device push-images <host> [options]

    -a, --architecture <auto|arm64|amd64>   (default: auto-detect)
    -m, --minimal                           Skip Grafana & Prometheus
        --skip-custom                        Skip api-service & control-service builds
        --images <chronograf,influxdb,...>   Push only named images

### Examples

    # All images, auto-detect architecture
    sie_generate_config device push-images 192.168.1.100

    # Just chronograf on an existing device
    sie_generate_config device push-images 192.168.1.100 --images chronograf

    # Minimal set, no custom builds
    sie_generate_config device push-images 192.168.1.100 -m --skip-custom

### TUI

- "Push Images" action in Device tab (hotkey `i`)
- "Skip Custom Images" config toggle

### How it works

1. **Pull** — `docker pull --platform linux/<arch>` on host
2. **Build** — `docker buildx build` custom services (unless `--skip-custom`)
3. **Save** — `docker save` to tars locally
4. **Transfer** — SFTP upload to device
5. **Load** — `docker load` on device via SSH
6. **Cleanup** — remove tars

### Offline workflow

    push-images -> update --local -> setup -> start

## Files changed

- `src/backend/deployment.rs` — `push_images()`, `find_docker_context()`
- `src/bin/cli.rs` — `push-images` subcommand
- `src/bin/tui.rs` — PushImages action, SkipCustom toggle
- `src/worker.rs` — `DevicePushImages` worker command